### PR TITLE
Made PerPage be of type object instead of int

### DIFF
--- a/WallHavenClient/WallHavenResponse.cs
+++ b/WallHavenClient/WallHavenResponse.cs
@@ -14,7 +14,7 @@ namespace WallHavenClient
 
         [JsonPropertyName("last_page")] public int LastPage { get; set; }
 
-        [JsonPropertyName("per_page")] public int PerPage { get; set; }
+        [JsonPropertyName("per_page")] public object PerPage { get; set; }
 
         [JsonPropertyName("total")] public int Total { get; set; }
 


### PR DESCRIPTION
The wallhaven api has an issue where the per_page field gets returned as a string (if we're using the wallhaven APi key) or as an integer (when we're not using the API key).

![withAPIKey](https://github.com/user-attachments/assets/a9b7f730-8bfa-4357-8ac3-5640257c232a)
![withoutAPIKey](https://github.com/user-attachments/assets/16dbbc38-775b-4c8e-b75b-8f7b360cf7c3)


Not sure if this was some sort of change or bug introduced after this library was released but having this parameter as an int throws a conversion error when using this library with an API key.

I have reported the issue with the API reply on wallhaven's Discord channel.